### PR TITLE
fix: inject Entity-assets read_path procedure once per turn

### DIFF
--- a/backend/packages/harness/evoflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/evoflow/agents/lead_agent/prompt.py
@@ -1206,17 +1206,24 @@ def build_memory_injection_sections(
             body_parts.append(safe_mem)
 
     # runtime-aligned Asset Hub: standing + read_path guidance + catalog (Tier 0)
+    # Shared Entity-assets procedure is injected at most once (user first, else workspace).
+    procedure_emitted = False
     try:
-        from evoflow.assets.guidance import build_session_asset_memory_block
+        from evoflow.assets.guidance import (
+            build_session_asset_memory_block,
+            session_asset_block_includes_procedure,
+        )
 
         asset_block = build_session_asset_memory_block(
             agent_name=agent_name,
             principal_id=principal_id,
+            include_procedure=True,
         )
         if asset_block.strip():
             safe_asset = scan_content(asset_block.strip(), source="asset_memory").strip()
             if safe_asset:
                 body_parts.append(safe_asset)
+                procedure_emitted = session_asset_block_includes_procedure(safe_asset)
     except Exception:
         logger.debug("asset memory injection skipped", exc_info=True)
 
@@ -1226,7 +1233,11 @@ def build_memory_injection_sections(
         try:
             from evoflow.agents.memory.workspace_memory import format_workspace_memory_context
 
-            ws_block = format_workspace_memory_context(lw, injection_profile=injection_profile).strip()
+            ws_block = format_workspace_memory_context(
+                lw,
+                injection_profile=injection_profile,
+                include_procedure=not procedure_emitted,
+            ).strip()
             if ws_block:
                 safe_ws = scan_content(ws_block, source="workspace_memory").strip()
                 if safe_ws:

--- a/backend/packages/harness/evoflow/agents/memory/workspace_memory.py
+++ b/backend/packages/harness/evoflow/agents/memory/workspace_memory.py
@@ -323,8 +323,13 @@ def format_workspace_memory_context(
     workspace_path: str | None,
     *,
     injection_profile: str = "full",
+    include_procedure: bool = True,
 ) -> str:
-    """Build ``<workspace_memory>`` catalog block (same disclosure as user assets)."""
+    """Build ``<workspace_memory>`` catalog block (same disclosure as user assets).
+
+    ``include_procedure``: in asset-hub mode, when False only emit the per-root
+    MEMORY_SUMMARY (shared read_path already injected once this turn).
+    """
     del injection_profile  # catalog form is always compact
     config = get_memory_config()
     if not config.enabled or not config.injection_enabled:
@@ -345,7 +350,9 @@ def format_workspace_memory_context(
             try:
                 from evoflow.assets.guidance import build_read_path_guidance
 
-                body = build_read_path_guidance(ref).strip()
+                body = build_read_path_guidance(
+                    ref, include_procedure=include_procedure
+                ).strip()
             except Exception:
                 logger.debug("workspace read_path guidance skipped", exc_info=True)
                 body = ""
@@ -361,7 +368,9 @@ def format_workspace_memory_context(
             try:
                 from evoflow.assets.guidance import build_read_path_guidance
 
-                guide = build_read_path_guidance(ref)
+                guide = build_read_path_guidance(
+                    ref, include_procedure=include_procedure
+                )
                 if guide.strip():
                     body = f"{guide.strip()}\n\n{body}" if body.strip() else guide.strip()
             except Exception:

--- a/backend/packages/harness/evoflow/assets/guidance.py
+++ b/backend/packages/harness/evoflow/assets/guidance.py
@@ -175,8 +175,30 @@ def resolve_session_entity(
     )
 
 
-def build_read_path_guidance(entity: EntityRef, *, standing: str | None = None) -> str:
-    """Render runtime ``read_path`` template with standing filled in."""
+def build_read_path_procedure() -> str:
+    """Shared Entity-assets read/write discipline (injected at most once per turn)."""
+    try:
+        from evoflow.assets.prompt_templates import load_memory_prompt
+
+        return load_memory_prompt("read_path").strip()
+    except Exception:
+        logger.debug("build_read_path_procedure failed", exc_info=True)
+        return ""
+
+
+def _entity_label(entity: EntityRef) -> str:
+    et = entity.normalized().entity_type
+    if et == "workspace":
+        return "Workspace"
+    if et == "employee":
+        return "Employee"
+    if et == "agent":
+        return "Agent"
+    return "User"
+
+
+def build_read_path_entity_block(entity: EntityRef, *, standing: str | None = None) -> str:
+    """Per-root layout + MEMORY_SUMMARY (no shared procedure)."""
     e = entity.normalized()
     rel = entity_relative_dir(e)
     base = f"assets/{rel}"
@@ -187,15 +209,39 @@ def build_read_path_guidance(entity: EntityRef, *, standing: str | None = None) 
     try:
         layout_lines, cross_entity_note = _entity_layout_lines(e)
         return render_memory_prompt(
-            "read_path",
+            "read_path_entity",
+            entity_label=_entity_label(e),
             entity_root=base,
             layout_lines=layout_lines,
             cross_entity_note=cross_entity_note,
             memory_summary=summary or "（尚无站立摘要）",
-        )
+        ).strip()
     except Exception:
-        logger.debug("build_read_path_guidance failed", exc_info=True)
+        logger.debug("build_read_path_entity_block failed", exc_info=True)
         return ""
+
+
+def build_read_path_guidance(
+    entity: EntityRef,
+    *,
+    standing: str | None = None,
+    include_procedure: bool = True,
+) -> str:
+    """Render read_path: optional shared procedure + per-entity summary."""
+    e = entity.normalized()
+    summary = standing if standing is not None else read_standing_text(e, max_chars=TIER0_STANDING_CHARS)
+    if asset_hub_memory_injection():
+        if standing_is_placeholder(summary) or not str(summary or "").strip():
+            return ""
+    parts: list[str] = []
+    if include_procedure:
+        proc = build_read_path_procedure()
+        if proc:
+            parts.append(proc)
+    ent = build_read_path_entity_block(e, standing=summary)
+    if ent:
+        parts.append(ent)
+    return "\n\n".join(parts)
 
 
 def _entity_layout_lines(entity: EntityRef) -> tuple[str, str]:
@@ -242,6 +288,7 @@ def build_entity_memory_injection(
     entity: EntityRef,
     *,
     include_read_guidance: bool = True,
+    include_procedure: bool = True,
     include_catalog: bool | None = None,
 ) -> str:
     """Tier-0 block: runtime read_path + standing (catalog off by default in asset-hub memory mode)."""
@@ -254,7 +301,9 @@ def build_entity_memory_injection(
     if asset_mode and (standing_is_placeholder(standing) or not standing.strip()):
         return ""
     if include_read_guidance:
-        guide = build_read_path_guidance(e, standing=standing)
+        guide = build_read_path_guidance(
+            e, standing=standing, include_procedure=include_procedure
+        )
         if guide.strip():
             parts.append(guide.strip())
     if include_catalog:
@@ -298,11 +347,15 @@ def build_session_asset_memory_block(
     *,
     agent_name: str | None = None,
     principal_id: str = "",
+    include_procedure: bool = True,
 ) -> str:
     """User/employee memory Tier-0 + optional agent SOUL summary.
 
     ``principal_id`` anchors the memory/standing entity to the caller's
     personal bucket so injected content matches what the Asset Center shows.
+
+    ``include_procedure``: when False, only the per-entity MEMORY_SUMMARY is
+    emitted (shared read_path text already injected elsewhere this turn).
     """
     try:
         from evoflow.assets.hub import ensure_entity_tree
@@ -310,7 +363,9 @@ def build_session_asset_memory_block(
         memory_ent = resolve_memory_entity(agent_name=agent_name, principal_id=principal_id)
         ensure_entity_tree(memory_ent)
         parts: list[str] = []
-        mem = build_entity_memory_injection(memory_ent)
+        mem = build_entity_memory_injection(
+            memory_ent, include_procedure=include_procedure
+        )
         if mem.strip():
             parts.append(mem.strip())
         soul = build_agent_soul_injection_block(agent_name=agent_name)
@@ -320,3 +375,9 @@ def build_session_asset_memory_block(
     except Exception:
         logger.debug("build_session_asset_memory_block failed", exc_info=True)
         return ""
+
+
+def session_asset_block_includes_procedure(block: str) -> bool:
+    """True when ``block`` already carries the shared Entity-assets procedure."""
+    text = str(block or "")
+    return "## Entity assets" in text or "assets(action=search" in text

--- a/backend/packages/harness/evoflow/assets/prompts/memories/README.md
+++ b/backend/packages/harness/evoflow/assets/prompts/memories/README.md
@@ -5,7 +5,9 @@ Provenance: upstream memory-template patterns, path-mapped to EvoFlow
 
 | File | Role | When used |
 |------|------|-----------|
-| `read_path.md` | How the **dialogue agent** uses memory | Injected every turn (Tier 0) with standing filled in |
+| `read_path.md` | Shared Entity-assets procedure (once per turn) | Tier 0; composed with entity blocks |
+| `read_path_entity.md` | Per-root layout + MEMORY_SUMMARY | Tier 0; one block per user/workspace/… |
+
 | `stage_one_system.md` | Phase 1 extract system | Background worker after idle session |
 | `stage_one_input.md` | Phase 1 user/input wrapper | Same |
 | `consolidation.md` | Phase 2 consolidate system | Background worker on entity lock |

--- a/backend/packages/harness/evoflow/assets/prompts/memories/read_path.md
+++ b/backend/packages/harness/evoflow/assets/prompts/memories/read_path.md
@@ -2,9 +2,9 @@
 
 ## Entity assets (memory, process, reflection, experience)
 
-You have access to an **asset folder** from prior runs. **Memory, episodic process,
+You have access to **asset folder(s)** from prior runs. **Memory, episodic process,
 journal reflections, and craft skills** share the same Markdown layout and the same
-read/write discipline — only paths and labels differ.
+read/write discipline — only roots and summaries differ (see sections below).
 
 Use assets when the task may depend on prior decisions, conventions, or learned procedures.
 
@@ -15,21 +15,14 @@ Decision boundary:
   or anything related to MEMORY_SUMMARY below.
 - If unsure, do a quick asset pass.
 
-Asset layout (general → specific):
-
-**Root:** `{{ entity_root }}/`
-
-{{ layout_lines }}
-{{ cross_entity_note }}
-
 **One tool for all families:** `assets(action=search|read|list|note|profile)`.
 Do **not** use legacy `experience_*`, separate memory DB tools, or direct edits to durable files.
 
 Quick asset pass (when applicable):
 
-1. Skim MEMORY_SUMMARY below; extract task-relevant keywords.
+1. Skim MEMORY_SUMMARY section(s) below; extract task-relevant keywords.
 2. `assets(action=search, …)` over `memory/MEMORY.md`, `memory/facts/`, `memory/episodic/`,
-   `memory/journal/`, `craft/`.
+   `memory/journal/`, `craft/` under the relevant root.
 3. Only if search hits specific paths, `assets(action=read, …)` **1–2** files.
 4. No relevant hits → stop lookup and continue.
 
@@ -66,9 +59,4 @@ Writing assets (same for memory, reflection, experience):
 - Do **not** edit `standing.md`, `MEMORY.md`, `facts/`, `journal/`, `craft/` directly.
 - Phase 2 consolidation merges inbox notes into durable files.
 
-========= MEMORY_SUMMARY BEGINS =========
-{{ memory_summary }}
-========= MEMORY_SUMMARY ENDS =========
-
 When assets are likely relevant, run the quick pass before deep repo exploration.
-

--- a/backend/packages/harness/evoflow/assets/prompts/memories/read_path_entity.md
+++ b/backend/packages/harness/evoflow/assets/prompts/memories/read_path_entity.md
@@ -1,0 +1,8 @@
+### {{ entity_label }} — `{{ entity_root }}/`
+
+{{ layout_lines }}
+{{ cross_entity_note }}
+
+========= MEMORY_SUMMARY BEGINS =========
+{{ memory_summary }}
+========= MEMORY_SUMMARY ENDS =========

--- a/backend/packages/harness/tests/test_asset_memory_injection.py
+++ b/backend/packages/harness/tests/test_asset_memory_injection.py
@@ -104,3 +104,50 @@ def test_build_memory_injection_sections_legacy_includes_sqlite_memory(monkeypat
     block = build_memory_injection_sections(agent_name="main")
     assert "<memory>" in block
     set_memory_config(MemoryConfig())
+
+
+def test_procedure_once_when_user_and_workspace(assets_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from evoflow.assets.paths import workspace_entity_ref
+    from evoflow.config.paths import reset_paths_cache
+
+    reset_paths_cache()
+    user = EntityRef("user", "user").normalized()
+    ensure_entity_tree(user)
+    (assets_home / "assets" / "user" / "memory" / "standing.md").write_text(
+        "v1\n\n用户主线：dedupe-read-path\n",
+        encoding="utf-8",
+    )
+
+    repo = assets_home / "proj"
+    repo.mkdir()
+    ws = workspace_entity_ref(str(repo))
+    ensure_entity_tree(ws)
+    (assets_home / "assets" / "workspaces" / ws.entity_id / "memory" / "standing.md").write_text(
+        "v1\n\n工作区：EvoFlow harness\n",
+        encoding="utf-8",
+    )
+
+    class _Cfg:
+        enabled = True
+        injection_enabled = True
+        injection_mode = "asset"
+        chat_compact_max_tokens = 800
+        max_injection_tokens = 2000
+
+    monkeypatch.setattr("evoflow.config.memory_config.get_memory_config", lambda: _Cfg())
+
+    block = build_memory_injection_sections(
+        agent_name="main",
+        local_workspace_root=str(repo),
+    )
+    assert block.count("## Entity assets") == 1
+    assert "Ask before deposit" in block
+    assert "dedupe-read-path" in block
+    assert "EvoFlow harness" in block
+    assert "<workspace_memory>" in block
+    assert "### User —" in block
+    assert "### Workspace —" in block
+    # Workspace block must not re-paste the shared procedure
+    ws_start = block.index("<workspace_memory>")
+    assert "## Entity assets" not in block[ws_start:]
+    assert "Ask before deposit" not in block[ws_start:]

--- a/backend/packages/harness/tests/test_asset_memory_search.py
+++ b/backend/packages/harness/tests/test_asset_memory_search.py
@@ -46,17 +46,25 @@ def entity_tree(assets_home: Path) -> EntityRef:
 def test_load_read_path_prompt():
     text = load_memory_prompt("read_path")
     assert "assets(action=search" in text
-    assert "MEMORY_SUMMARY BEGINS" in text
+    assert "## Entity assets" in text
+    assert "{{ layout_lines }}" not in text
+    assert "MEMORY_SUMMARY BEGINS" not in text
+
+
+def test_load_read_path_entity_prompt():
+    text = load_memory_prompt("read_path_entity")
+    assert "{{ entity_root }}" in text
     assert "{{ layout_lines }}" in text
-    assert "**Root:**" in text
+    assert "MEMORY_SUMMARY BEGINS" in text
 
 
 def test_render_read_path_fills_summary():
-    from evoflow.assets.guidance import _entity_layout_lines
+    from evoflow.assets.guidance import _entity_layout_lines, build_read_path_guidance
 
     layout_lines, cross = _entity_layout_lines(EntityRef("user", "user"))
     out = render_memory_prompt(
-        "read_path",
+        "read_path_entity",
+        entity_label="User",
         entity_root="assets/user",
         layout_lines=layout_lines,
         cross_entity_note=cross,
@@ -67,6 +75,14 @@ def test_render_read_path_fills_summary():
     assert "- memory/standing.md" in out
     assert "用户喜欢简短回复" in out
     assert "MEMORY_SUMMARY BEGINS" in out
+
+    composed = build_read_path_guidance(
+        EntityRef("user", "user"),
+        standing="用户喜欢简短回复",
+        include_procedure=True,
+    )
+    assert composed.count("## Entity assets") == 1
+    assert "用户喜欢简短回复" in composed
 
 
 def test_search_any_mode(entity_tree: EntityRef):

--- a/backend/packages/harness/tests/test_read_path_layout.py
+++ b/backend/packages/harness/tests/test_read_path_layout.py
@@ -50,7 +50,22 @@ def test_read_path_guidance_root_once(assets_home: Path) -> None:
     block = build_read_path_guidance(ref)
     root = f"assets/workspaces/{ref.entity_id}"
     assert block.count(root) == 1
-    assert f"**Root:** `{root}/`" in block
+    assert f"### Workspace — `{root}/`" in block
     assert f"{root}/memory/standing.md" not in block
     assert "- memory/standing.md" in block
     assert "profile/basic-info" not in block
+    assert block.count("## Entity assets") == 1
+
+
+def test_read_path_entity_only_skips_procedure(assets_home: Path) -> None:
+    ref = workspace_entity_ref(str(assets_home / "repo"))
+    ensure_entity_tree(ref)
+    standing = assets_home / "assets" / "workspaces" / ref.entity_id / "memory" / "standing.md"
+    standing.parent.mkdir(parents=True, exist_ok=True)
+    standing.write_text("# 项目\n\nEvoFlow backend harness\n", encoding="utf-8")
+
+    block = build_read_path_guidance(ref, include_procedure=False)
+    assert "## Entity assets" not in block
+    assert "assets(action=search" not in block
+    assert "MEMORY_SUMMARY BEGINS" in block
+    assert "EvoFlow backend harness" in block


### PR DESCRIPTION
## Summary
- Split shared Entity-assets read/write procedure from per-root MEMORY_SUMMARY blocks.
- Inject the procedure at most once per turn (user first, else workspace) so bound workspaces no longer duplicate the full guidance paste.
- Add regression coverage for the single-procedure composition.

## Test plan
- [x] pytest harness: test_asset_memory_injection / test_asset_memory_search / test_read_path_layout / test_workspace_memory
- [ ] Spot-check Tier-0 injection with user+workspace standing: one Entity assets heading, two summaries

Made with [Cursor](https://cursor.com)